### PR TITLE
added grid charge and generator charge enable registers

### DIFF
--- a/deye_controller/modbus/protocol.py
+++ b/deye_controller/modbus/protocol.py
@@ -502,6 +502,8 @@ class HoldingRegisters:
     GridChargeStartVolts = FloatType(126, 'grid_charge_start_voltage', 100, suffix='V')
     GridChargeStartCapacity = IntType(127, 'grid_charge_start_soc', suffix='%')
     GridChargeCurrent = IntType(128, 'grid_charge_current', suffix='A')
+    GeneratorChargeEnable = BoolType(129, 'gen_charge_enable')
+    GridChargeEnable = BoolType(130, 'grid_charge_enable')
 
     """ Smart Load control - need more info  """
     GeneratorPortSetup = GenPortUse()


### PR DESCRIPTION
I added 2 registers in the deye controller that were not defined in protocol.py. They can be useful.

I use grid charge enable and address 130 together with time_of_use_enable to  prevent my EVSE.
I need  to disable grid charge  because my sell programming includes grid charge prior to time periods wehen I have higher price of electricity.  

Tested on Deye 3-phase EU 8kW inverter.

Regards,

Piotr